### PR TITLE
Power up

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^25.0.6",
     "@typescript-eslint/eslint-plugin": "^8.53.0",
     "@typescript-eslint/parser": "^8.53.0",
-    "bc-stubs": "^122.0.0",
+    "bc-stubs": "^124.0.0",
     "dompurify": "^3.3.1",
     "eslint": "^9.39.2",
     "eslint-plugin-react": "^7.37.5",

--- a/src/base.ts
+++ b/src/base.ts
@@ -84,12 +84,7 @@ export default class CRABS {
    * @returns void
    */
   public fakePlayerCommand(action: string = "all"): void {
-    for (const [_, COMMAND] of Commands.entries()) {
-      if (COMMAND.Tag === `crabs`) {
-        COMMAND.Action(action);
-        break;
-      }
-    }
+    CommandExecute(["crabs", action].join(" "));
   }
 
   /**
@@ -134,7 +129,7 @@ export default class CRABS {
    *  @returns {boolean} True if found, false if not.
    */
   protected detectMod(targetmod: string): boolean {
-    let modlist = bcModSdk.getModsInfo();
+    const modlist = bcModSdk.getModsInfo();
     return modlist.filter((x) => x.name == targetmod).length > 0;
   }
 
@@ -351,9 +346,9 @@ export default class CRABS {
     hex = hex.replace(/^#/, "");
 
     // Parse the red, green, and blue components
-    let red = parseInt(hex.slice(0, 2), 16);
-    let green = parseInt(hex.slice(2, 4), 16);
-    let blue = parseInt(hex.slice(4, 6), 16);
+    const red = parseInt(hex.slice(0, 2), 16);
+    const green = parseInt(hex.slice(2, 4), 16);
+    const blue = parseInt(hex.slice(4, 6), 16);
 
     // Return the rgba value with alpha transparency
     return `rgba(${red}, ${green}, ${blue}, ${alpha})`;

--- a/src/bcx.ts
+++ b/src/bcx.ts
@@ -1,0 +1,24 @@
+let bcxModApi: BCX_ModAPI | null = null;
+
+/**
+ * Wrapped for initialization of our own mod access to BCX's configuration.
+ * 
+ * This must be called *after* login, otherwise it'll break as BCX doesn't install `window.bcx` before that.
+ */
+export function getBcxApi(): BCX_ModAPI | null {
+    if (!window.bcx) return null;
+    if (!bcxModApi) {
+        bcxModApi = window.bcx.getModApi(NICKNAME);
+    }
+    return bcxModApi;
+}
+
+/**
+ * Check for BCX's availability and rule state
+ */
+export function isBCXRuleEnforced<ID extends BCX_Rule>(name: ID): boolean {
+    const api = getBcxApi();
+    if (!api) return false; // BCX not available, don't bother.
+    const rule = api.getRuleState(name);
+    return !rule?.isEnforced;
+}

--- a/src/bcxExternalInterface.d.ts
+++ b/src/bcxExternalInterface.d.ts
@@ -1,0 +1,227 @@
+/* eslint-disable */
+// Uncomment this if you are not using rest of BCX declaration files (declarations.d.ts, messages.d.ts)
+/*
+type BCX_Rule = string;
+type RuleDisplayDefinition<ID extends BCX_Rule> = any;
+type ConditionsConditionData<category extends string = string> = any;
+type RuleCustomData = Record<BCX_Rule, any>;
+type RuleInternalData = Record<BCX_Rule, any>;
+type BCX_queries = Record<string, [any, any]>;
+
+/* End of area to uncomment */
+
+interface BCXVersion {
+	major: number;
+	minor: number;
+	patch: number;
+	extra?: string;
+	dev?: boolean;
+}
+
+//#region Rules
+interface BCX_RuleStateAPI_Generic {
+	/** The name of the rule */
+	readonly rule: string;
+	/** Definition of the rule */
+	readonly ruleDefinition: any;
+
+	/** Current condition data of the rule */
+	readonly condition: any;
+
+	/** If the rule is in effect (active and all conditions valid) */
+	readonly inEffect: boolean;
+	/** If the rule is enforced (inEffect and enforce enabled) */
+	readonly isEnforced: boolean;
+	/** If the rule is logged (inEffect and logging enabled) */
+	readonly isLogged: boolean;
+
+	/** Rule setttings */
+	readonly customData: any;
+	/** Rule internal data */
+	readonly internalData: any;
+
+	/**
+	 * Triggers and logs that Player violated this rule
+	 * @param targetCharacter - If the rule is against specific target different than player (e.g. sending message/beep), this adds it to log
+	 * @param dictionary - Dictionary of rule-specific text replacements in logs and notifications; see implementation of individual rules
+	 */
+	trigger(targetCharacter?: number | null, dictionary?: Record<string, string>): void;
+
+	/**
+	 * Triggers and logs that Player attempted to violate this rule, but the attempt was blocked (for enforced rules)
+	 * @param targetCharacter - If the rule is against specific target different than player (e.g. sending message/beep), this adds it to log
+	 * @param dictionary - Dictionary of rule-specific text replacements in logs and notifications; see implementation of individual rules
+	 */
+	triggerAttempt(targetCharacter?: number | null, dictionary?: Record<string, string>): void;
+}
+
+interface BCX_RuleStateAPI<ID extends BCX_Rule> extends BCX_RuleStateAPI_Generic {
+	readonly rule: ID;
+	readonly ruleDefinition: RuleDisplayDefinition<ID>;
+
+	readonly condition: ConditionsConditionData<"rules"> | undefined;
+
+	readonly customData: ID extends keyof RuleCustomData ? (RuleCustomData[ID] | undefined) : undefined;
+	readonly internalData: ID extends keyof RuleInternalData ? (RuleInternalData[ID] | undefined) : undefined;
+}
+
+//#endregion
+
+//#region Curses
+
+interface BCX_CurseInfo {
+	/** Whether the curse is active or disabled */
+	readonly active: boolean;
+
+	/** The group this info is for */
+	readonly group: AssetGroupName;
+	/** BC asset the curse keeps, or `null` if the group is cursed to be empty */
+	readonly asset: Asset | null;
+
+	/** What color the item is cursed with */
+	readonly color?: ItemColor;
+	/** Whether properties are cursed (if set, `Property` is enforced, otherwise only applied on item re-apply) */
+	readonly curseProperty: boolean;
+	/** The properties that are enforced */
+	readonly property?: ItemProperties;
+	/** Crafting data, always cursed */
+	readonly craft?: CraftingItem;
+}
+
+//#endregion
+
+interface BCX_Events {
+	curseTrigger: {
+		/** Which action the curses did to the item */
+		action: "remove" | "add" | "swap" | "update" | "color" | "autoremove";
+		/** Name of asset group that was changed */
+		group: string;
+	};
+	/**
+	 * Triggers whenever a rule triggers (either by BCX or by external API)
+	 * @note If you need extra data about rule's configuration, use `BCX_ModAPI.getRuleState`
+	 */
+	ruleTrigger: {
+		/** The rule that was triggered */
+		rule: BCX_Rule;
+		/**
+		 * Type of trigger that happened:
+		 * - `trigger` - The action this rule dected did happen (e.g. because the rule was not enforced)
+		 * - `triggerAttempt` - The action was caught by the rule and did not happen
+		 */
+		triggerType: "trigger" | "triggerAttempt";
+		/**
+		 * Character that was being targetted (e.g. for whisper/beep rules, possibly few others).
+		 * Most rules do not use this.
+		 */
+		targetCharacter: number | null;
+	};
+	/**
+	 * Triggers whenever player changes subscreen in BCX.
+	 * Note, that some changes might not be observable by outside mod (e.g. when user simply switches to different subscreen).
+	 * This can trigger even outside of `InformationSheet` screen.
+	 */
+	bcxSubscreenChange: {
+		/**
+		 * Whether BCX is currently showing one of custom screens, overriding the default BC screen.
+		 *
+		 * At the time of emitting, this value is the same as the one returned by `bcx.inBcxSubscreen()`.
+		 */
+		inBcxSubscreen: boolean;
+	};
+	/**
+	 * Triggers whenever BCX sends a "local" message to the chat.
+	 */
+	bcxLocalMessage: {
+		/** The actual message that is to be displayed */
+		message: string | Node;
+		/** Timeout of the message - if set, the message auto-hides after {timeout} milliseconds */
+		timeout?: number;
+		/** Sender metadata (used for displaying a membernumber on some messages) */
+		sender?: number;
+	};
+	/**
+	 * This is a generic event sent out by anyone in the room (including Player) when _something_ in BCX configuration changes,
+	 * which might warrant requesting updated data from the user, if you hold onto any such data in your logic.
+	 */
+	somethingChanged: {
+		/** MemberNumber of the sender. `Player.MemberNumber` will be used when triggered by this BCX instance. */
+		sender: number;
+	};
+}
+
+interface BCX_ModAPI extends BCXEventEmitter<BCX_Events> {
+	/** Name of the mod this API was requested for */
+	readonly modName: string;
+
+	/** Returns state handler for a rule or `null` for unknown rule */
+	getRuleState<ID extends BCX_Rule>(rule: ID): BCX_RuleStateAPI<ID> | null;
+
+	/** Returns info about how a slot is cursed */
+	getCurseInfo(group: AssetGroupName): BCX_CurseInfo | null;
+
+	/**
+	 * Sends a BCX query to another character in the same room, or to Player.
+	 * This allows same level of access to BCX data as BCX itself has for others, which includes almost all actions possible through UI (but there are exceptions).
+	 * Requests done to "Player" will have the same limitations user has when interacting with the UI.
+	 *
+	 * This is a very low-level API and properly forming and interpretting the requests requires care.
+	 * Also note, that this method sends requests to other characters, which might respond in an arbitrary way or not at all.
+	 * Also consider that using this with different target than "Player" sends a message through BC's server and is subject to rate limiting.
+	 * @param type - The type of query to send
+	 * @param data - Data for the query
+	 * @param target - MemberNumber to target; "Player" is alias for `Player.MemberNumber`
+	 * @param timeout - Timeout after which the query fails, in milliseconds; defaults to 10 seconds
+	 * @returns Promise that resolves to the query answer or rejects if the request failed
+	 * @see BCX_queries in messages.d.ts for list of possible queries, their expected data and answers
+	 */
+	sendQuery<T extends keyof BCX_queries>(
+		type: T,
+		data: BCX_queries[T][0],
+		target: number | "Player",
+		timeout?: number,
+	): Promise<BCX_queries[T][1]>;
+}
+
+interface BCX_ConsoleInterface {
+	/** Version of loaded BCX */
+	readonly version: string;
+
+	/** Version parsed to components */
+	readonly versionParsed: Readonly<BCXVersion>;
+
+	/**
+	 * Gets BCX version of another character in room
+	 * @param target - The membernumber of character to get; undefined = Player
+	 */
+	getCharacterVersion(target?: number): string | null;
+
+	/** Gets if BCX runs in development mode */
+	readonly isDevel: boolean;
+
+	/**
+	 * Get access to BCX Mod API.
+	 * @param mod - Same identifier of your mod as used for ModSDK
+	 */
+	getModApi(mod: string): BCX_ModAPI;
+
+	/** Whether BCX is currently showing one of custom screens, overriding the default BC screen. */
+	inBcxSubscreen(): boolean;
+}
+
+interface Window {
+	bcx?: BCX_ConsoleInterface;
+}
+
+type BCXEvent = Record<never, unknown>;
+type BCXAnyEvent<T extends BCXEvent> = {
+	[key in keyof T]: {
+		event: key;
+		data: T[key];
+	};
+}[keyof T];
+
+interface BCXEventEmitter<T extends BCXEvent> {
+	on<K extends keyof T>(s: K, listener: (v: T[K]) => void): () => void;
+	onAny(listener: (value: BCXAnyEvent<T>) => void): () => void;
+}

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,796 @@
+/** Package version, provided by rollup */
+declare const BCX_VERSION: string;
+declare const BCX_DEVEL: boolean;
+declare const BCX_SAVE_AUTH: string;
+
+interface Window {
+	BCX_Loaded?: boolean;
+}
+
+type Satisfies<T extends U, U> = T;
+
+type BCXSupporterType = undefined | "supporter" | "developer";
+
+interface PlayerOnlineSettings {
+	/** Saved BCX data */
+	BCX?: string;
+	/** The last time BCX data was cleared (debug helper) */
+	BCXDataCleared?: number;
+}
+
+/** BCX added buttons to the character dialog */
+type BCX_DialogMenuButton =
+	| "BCX_RemoteDisabled"
+	| "BCX_UnlockDisabled"
+	| "BCX_PickLockDisabled"
+	| "BCX_LockDisabled"
+	| "BCX_RemoveDisabled"
+	| "BCX_StruggleDisabled"
+	| "BCX_DismountDisabled"
+	| "BCX_EscapeDisabled"
+	| "BCX_ActivityDisabled"
+	| "BCX_Search"
+	| "BCX_SearchExit"
+	| DialogMenuButton;
+
+type BCX_BackgroundTag =
+	| "[BCX] Hidden"
+	| BackgroundTag;
+
+type BCX_Permissions =
+	| "authority_edit_min"
+	| "authority_grant_self"
+	| "authority_revoke_self"
+	| "authority_mistress_add"
+	| "authority_mistress_remove"
+	| "authority_owner_add"
+	| "authority_owner_remove"
+	| "authority_view_roles"
+	| "log_view_normal"
+	| "log_view_protected"
+	| "log_configure"
+	| "log_delete"
+	| "log_praise"
+	| "log_add_note"
+	| "curses_normal"
+	| "curses_limited"
+	| "curses_global_configuration"
+	| "curses_change_limits"
+	| "curses_color"
+	| "curses_view_originator"
+	| "rules_normal"
+	| "rules_limited"
+	| "rules_global_configuration"
+	| "rules_change_limits"
+	| "rules_view_originator"
+	| "commands_normal"
+	| "commands_limited"
+	| "commands_change_limits"
+	| "exportimport_export"
+	| "relationships_view_all"
+	| "relationships_modify_self"
+	| "relationships_modify_others"
+	| "misc_cheat_allowactivities"
+	| "misc_wardrobe_item_import";
+
+type PermissionsBundle = Record<string, [boolean, number]>;
+
+interface PermissionRoleBundle {
+	mistresses: [number, string][];
+	owners: [number, string][];
+	allowAddMistress: boolean;
+	allowRemoveMistress: boolean;
+	allowAddOwner: boolean;
+	allowRemoveOwner: boolean;
+}
+
+type BCX_LogCategory =
+	| "permission_change"
+	| "log_config_change"
+	| "log_deleted"
+	| "praise"
+	| "user_note"
+	| "curse_change"
+	| "curse_trigger"
+	| "rule_change"
+	| "rule_trigger"
+	| "command_change"
+	| "had_orgasm"
+	| "entered_public_room"
+	| "entered_private_room"
+	| "authority_roles_change"
+	| "relationships_change";
+
+interface CursedItemInfo {
+	Name: string;
+	curseProperty: boolean;
+	Color?: string | string[];
+	Difficulty?: number;
+	Property?: ItemProperties;
+	Craft?: CraftingItem;
+	itemRemove?: true | undefined;
+}
+
+interface ConditionsCategoryKeys {
+	curses: AssetGroupName;
+	rules: BCX_Rule;
+	commands: BCX_Command;
+}
+
+type ConditionsCategories = keyof ConditionsCategoryKeys;
+
+interface ConditionsCategorySpecificData {
+	curses: CursedItemInfo | null;
+	rules: {
+		enforce?: false;
+		log?: false;
+		/** `RuleCustomData` */
+		customData?: Record<string, any>;
+		/** `RuleInternalData` */
+		internalData?: any;
+	};
+	commands: undefined;
+}
+
+interface ConditionsCategorySpecificGlobalData {
+	curses: {
+		itemRemove: boolean;
+	};
+	rules: undefined;
+	commands: undefined;
+}
+
+interface ConditionsCategorySpecificPublicData {
+	curses: {
+		Name: string;
+		curseProperties: boolean;
+		itemRemove: boolean;
+	} | null;
+	rules: {
+		enforce: boolean;
+		log: boolean;
+		/** `RuleCustomData` */
+		customData?: Record<string, any>;
+	};
+	commands: undefined;
+}
+
+interface ConditionsConditionRequirements {
+	/** If the conditions should be treated as "OR". Default is "AND" */
+	orLogic?: true;
+	room?: {
+		type: "public" | "private";
+		inverted?: true;
+	};
+	roomName?: {
+		name: string;
+		inverted?: true;
+	};
+	role?: {
+		role: import("./modules/authority").AccessLevel;
+		inverted?: true;
+	};
+	player?: {
+		memberNumber: number;
+		inverted?: true;
+	};
+}
+
+interface ConditionsConditionData<category extends ConditionsCategories = ConditionsCategories> {
+	active: boolean;
+	lastActive: boolean;
+	data: ConditionsCategorySpecificData[category];
+	timer?: number;
+	timerRemove?: true | undefined;
+	requirements?: ConditionsConditionRequirements;
+	favorite?: true | undefined;
+	addedBy?: number;
+}
+
+interface ConditionsConditionPublicDataBase {
+	active: boolean;
+	timer: number | null;
+	timerRemove: boolean;
+	requirements: ConditionsConditionRequirements | null;
+	favorite: boolean;
+}
+
+interface ConditionsConditionPublicData<category extends ConditionsCategories = ConditionsCategories> extends ConditionsConditionPublicDataBase {
+	data: ConditionsCategorySpecificPublicData[category];
+	addedBy?: number;
+}
+
+type ConditionsCategoryRecord<category extends ConditionsCategories = ConditionsCategories> = Partial<Record<ConditionsCategoryKeys[category], ConditionsConditionData<category>>>;
+type ConditionsCategoryPublicRecord<category extends ConditionsCategories = ConditionsCategories> = Partial<Record<ConditionsCategoryKeys[category], ConditionsConditionPublicData<category>>>;
+
+interface ConditionsCategoryData<category extends ConditionsCategories = ConditionsCategories> {
+	conditions: Partial<Record<ConditionsCategoryKeys[category], ConditionsConditionData<category>>>;
+	/** List of limited/blocked conditions; defaults to normal */
+	limits: { [P in ConditionsCategoryKeys[category]]?: import("./constants").ConditionsLimit };
+	requirements: ConditionsConditionRequirements;
+	timer?: number;
+	timerRemove?: true | undefined;
+	data: ConditionsCategorySpecificGlobalData[category];
+}
+
+interface ConditionsCategoryConfigurableData<category extends ConditionsCategories = ConditionsCategories> {
+	requirements: ConditionsConditionRequirements;
+	timer: number | null;
+	timerRemove: boolean;
+	data: ConditionsCategorySpecificGlobalData[category];
+}
+
+interface ConditionsCategoryPublicData<category extends ConditionsCategories = ConditionsCategories> extends ConditionsCategoryConfigurableData<category> {
+	access_normal: boolean;
+	access_limited: boolean;
+	access_configure: boolean;
+	access_changeLimits: boolean;
+	highestRoleInRoom: import("./modules/authority").AccessLevel | null;
+	conditions: ConditionsCategoryPublicRecord<category>;
+	/** List of limited/blocked conditions; defaults to normal */
+	limits: { [P in ConditionsCategoryKeys[category]]?: import("./constants").ConditionsLimit };
+}
+
+type ConditionsStorage = Partial<{
+	[category in ConditionsCategories]: ConditionsCategoryData<category>;
+}>;
+
+type BCX_Rule =
+	| "block_remoteuse_self"
+	| "block_remoteuse_others"
+	| "block_keyuse_self"
+	| "block_keyuse_others"
+	| "block_lockpicking_self"
+	| "block_lockpicking_others"
+	| "block_lockuse_self"
+	| "block_lockuse_others"
+	| "block_wardrobe_access_self"
+	| "block_wardrobe_access_others"
+	| "block_restrict_allowed_poses"
+	| "block_creating_rooms"
+	| "block_entering_rooms"
+	| "block_leaving_room"
+	| "block_freeing_self"
+	| "block_tying_others"
+	| "block_blacklisting"
+	| "block_whitelisting"
+	| "block_antiblind"
+	| "block_difficulty_change"
+	| "block_activities"
+	| "block_mainhall_maidrescue"
+	| "block_action"
+	| "block_BCX_permissions"
+	| "block_curses_self_by_others"
+	| "block_rules_self_by_others"
+	| "block_room_admin_UI"
+	| "block_using_ggts"
+	| "block_club_slave_work"
+	| "block_using_unowned_items"
+	| "block_changing_emoticon"
+	| "block_ui_icons_names"
+	| "alt_restrict_hearing"
+	| "alt_restrict_sight"
+	| "alt_eyes_fullblind"
+	| "alt_field_of_vision"
+	| "alt_blindfolds_fullblind"
+	| "alt_always_slow"
+	| "alt_set_leave_slowing"
+	| "alt_control_orgasms"
+	| "alt_secret_orgasms"
+	| "alt_room_admin_transfer"
+	| "alt_room_admin_limit"
+	| "alt_set_profile_description"
+	| "alt_set_nickname"
+	| "alt_force_suitcase_game"
+	| "alt_hearing_whitelist"
+	| "alt_seeing_whitelist"
+	| "alt_restrict_leashability"
+	| "alt_hide_friends"
+	| "alt_forced_summoning"
+	| "alt_allow_changing_appearance"
+	| "rc_club_owner"
+	| "rc_lover_new"
+	| "rc_lover_leave"
+	| "rc_sub_new"
+	| "rc_sub_leave"
+	| "speech_specific_sound"
+	| "speech_block_gagged_ooc"
+	| "speech_block_ooc"
+	| "speech_doll_talk"
+	| "speech_ban_words"
+	| "speech_ban_words_in_emotes"
+	| "speech_forbid_open_talking"
+	| "speech_limit_open_talking"
+	| "speech_forbid_emotes"
+	| "speech_limit_emotes"
+	| "speech_restrict_whisper_send"
+	| "speech_restrict_whisper_receive"
+	| "speech_restrict_beep_send"
+	| "speech_restrict_beep_receive"
+	| "speech_greet_order"
+	| "speech_block_antigarble"
+	| "speech_replace_spoken_words"
+	// | "speech_using_honorifics"
+	| "speech_force_retype"
+	| "greet_room_order"
+	| "greet_new_guests"
+	| "farewell_on_slow_leave"
+	// | "speech_restrained_speech"
+	| "speech_alter_faltering"
+	| "speech_mandatory_words"
+	| "speech_mandatory_words_in_emotes"
+	| "speech_partial_hearing"
+	| "speech_garble_while_talking"
+	| "other_forbid_afk"
+	| "other_track_time"
+	| "other_constant_reminder"
+	| "other_log_money"
+	// | "other_restrict_console_usage"
+	| "other_track_BCX_activation"
+	| "setting_item_permission"
+	| "setting_forbid_lockpicking"
+	| "setting_forbid_SP_rooms"
+	| "setting_forbid_safeword"
+	| "setting_arousal_meter"
+	| "setting_block_vibe_modes"
+	| "setting_arousal_stutter"
+	| "setting_show_afk"
+	| "setting_allow_body_mod"
+	| "setting_forbid_cosplay_change"
+	| "setting_sensdep"
+	| "setting_hide_non_adjecent"
+	| "setting_blind_room_garbling"
+	| "setting_relog_keeps_restraints"
+	| "setting_leashed_roomchange"
+	| "setting_room_rejoin"
+	| "setting_plug_vibe_events"
+	| "setting_allow_tint_effects"
+	| "setting_allow_blur_effects"
+	| "setting_upsidedown_view"
+	| "setting_random_npc_events"
+	;
+
+type RuleCustomData = {
+	block_restrict_allowed_poses: {
+		poseButtons: AssetPoseName[];
+	};
+	block_entering_rooms: {
+		roomList: string[];
+	};
+	block_leaving_room: {
+		minimumRole: import("./modules/authority").AccessLevel;
+	};
+	block_freeing_self: {
+		allowEasyItemsToggle: boolean;
+	};
+	block_tying_others: {
+		onlyMoreDominantsToggle: boolean;
+	};
+	block_keyuse_others: {
+		allowOwnerLocks: boolean;
+		allowLoverLocks: boolean;
+	};
+	block_blacklisting: {
+		minimumRole: import("./modules/authority").AccessLevel;
+	};
+	block_ui_icons_names: {
+		hidingStrength: string;
+		alsoHideEmoticons: boolean;
+	};
+	alt_restrict_hearing: {
+		deafeningStrength: string;
+	};
+	alt_restrict_sight: {
+		blindnessStrength: string;
+	};
+	alt_eyes_fullblind: {
+		affectPlayer: boolean;
+		hideNames: boolean;
+	};
+	alt_set_leave_slowing: {
+		leaveTime: number;
+	};
+	alt_field_of_vision: {
+		affectPlayer: boolean;
+		hideNames: boolean;
+	};
+	alt_control_orgasms: {
+		orgasmHandling: string;
+	};
+	alt_room_admin_transfer: {
+		minimumRole: import("./modules/authority").AccessLevel;
+		removeAdminToggle: boolean;
+	};
+	alt_set_profile_description: {
+		playersProfileDescription: string;
+	};
+	alt_set_nickname: {
+		nickname: string;
+		restore: boolean;
+	};
+	alt_hearing_whitelist: {
+		whitelistedMembers: number[];
+		ignoreGaggedMembersToggle: boolean;
+	};
+	alt_seeing_whitelist: {
+		whitelistedMembers: number[];
+	};
+	alt_restrict_leashability: {
+		minimumRole: import("./modules/authority").AccessLevel;
+	};
+	alt_hide_friends: {
+		allowedMembers: number[];
+	};
+	alt_forced_summoning: {
+		allowedMembers: number[];
+		summoningText: string;
+		summonTime: number;
+	};
+	alt_allow_changing_appearance: {
+		minimumRole: import("./modules/authority").AccessLevel;
+	};
+	speech_specific_sound: {
+		soundWhitelist: string[];
+	};
+	speech_doll_talk: {
+		maxWordLength: number;
+		maxNumberOfWords: number;
+	};
+	speech_ban_words: {
+		bannedWords: string[];
+	};
+	speech_ban_words_in_emotes: {
+		bannedWords: string[];
+	};
+	speech_restrict_whisper_send: {
+		minimumPermittedRole: import("./modules/authority").AccessLevel;
+	};
+	speech_restrict_whisper_receive: {
+		minimumPermittedRole: import("./modules/authority").AccessLevel;
+		autoreplyText: string;
+	};
+	speech_restrict_beep_send: {
+		whitelistedMemberNumbers: number[];
+		onlyWhenBound: boolean;
+	};
+	speech_restrict_beep_receive: {
+		whitelistedMemberNumbers: number[];
+		autoreplyText: string;
+		onlyWhenBound: boolean;
+	};
+	speech_greet_order: {
+		toGreetMemberNumbers: number[];
+	};
+	speech_limit_open_talking: {
+		maxNumberOfMsg: number;
+	};
+	speech_limit_emotes: {
+		maxNumberOfEmotes: number;
+	};
+	speech_replace_spoken_words: {
+		stringWithReplacingSyntax: string;
+	};
+	// speech_using_honorifics: {
+	// 	stringWithRuleSyntax: string;
+	// },
+	greet_room_order: {
+		greetingSentence: string;
+		affectEmotes: boolean;
+	};
+	greet_new_guests: {
+		greetingSentence: string;
+		minimumRole: Exclude<import("./modules/authority").AccessLevel, 0>;
+	};
+	farewell_on_slow_leave: {
+		greetingSentence: string;
+	};
+	// speech_restrained_speech: {
+	// 	listOfAllowedSentences: string[];
+	// },
+	speech_mandatory_words: {
+		mandatoryWords: string[];
+		affectWhispers: boolean;
+	};
+	speech_mandatory_words_in_emotes: {
+		mandatoryWords: string[];
+	};
+	speech_partial_hearing: {
+		alwaysUnderstandableWords: string[];
+		randomUnderstanding: boolean;
+		affectGaggedMembersToggle: boolean;
+	};
+	speech_garble_while_talking: {
+		gagLevel: number;
+	};
+	other_forbid_afk: {
+		minutesBeforeAfk: number;
+	};
+	other_constant_reminder: {
+		reminderText: string[];
+		reminderFrequency: number;
+	};
+	other_log_money: {
+		logEarnings: boolean;
+	};
+	other_track_time: {
+		minimumPermittedRole: import("./modules/authority").AccessLevel;
+	};
+	setting_item_permission: {
+		value: string;
+	};
+	setting_forbid_lockpicking: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_forbid_SP_rooms: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_forbid_safeword: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_arousal_meter: {
+		active: ArousalActiveName;
+		visible: ArousalVisibleName;
+	};
+	setting_block_vibe_modes: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_arousal_stutter: {
+		value: ArousalAffectStutterName;
+	};
+	setting_show_afk: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_allow_body_mod: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_forbid_cosplay_change: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_sensdep: {
+		value: SettingsSensDepName;
+		disableExamine: boolean;
+		hideMessages: boolean;
+	};
+	setting_hide_non_adjecent: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_blind_room_garbling: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_relog_keeps_restraints: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_leashed_roomchange: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_room_rejoin: {
+		value: boolean;
+		remakeRooms: boolean;
+	};
+	setting_plug_vibe_events: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_allow_tint_effects: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_allow_blur_effects: {
+		value: boolean;
+		restore: boolean;
+	};
+	setting_upsidedown_view: {
+		value: boolean;
+		restore: boolean;
+	};
+};
+
+type RuleInternalData = {
+	alt_set_nickname: string;
+	setting_forbid_lockpicking: boolean;
+	setting_forbid_SP_rooms: boolean;
+	setting_forbid_safeword: boolean;
+	setting_block_vibe_modes: boolean;
+	setting_show_afk: boolean;
+	setting_allow_body_mod: boolean;
+	setting_forbid_cosplay_change: boolean;
+	setting_hide_non_adjecent: boolean;
+	setting_blind_room_garbling: boolean;
+	setting_relog_keeps_restraints: boolean;
+	setting_leashed_roomchange: boolean;
+	setting_plug_vibe_events: boolean;
+	setting_allow_tint_effects: boolean;
+	setting_allow_blur_effects: boolean;
+	setting_upsidedown_view: boolean;
+	other_log_money: number;
+	other_track_BCX_activation: number;
+	other_track_time: number;
+};
+
+type RuleCustomDataTypesMap = {
+	listSelect: string;
+	memberNumberList: number[];
+	number: number;
+	poseSelect: string[];
+	roleSelector: import("./modules/authority").AccessLevel;
+	string: string;
+	stringList: string[];
+	textArea: string;
+	toggle: boolean;
+};
+type RuleCustomDataTypes = keyof RuleCustomDataTypesMap;
+type RuleCustomDataTypesOptions = {
+	listSelect: [string, string][];
+	memberNumberList?: {
+		pageSize?: number;
+	};
+	number?: {
+		min?: number;
+		max?: number;
+	};
+	string?: RegExp;
+	stringList?: {
+		validate?: RegExp;
+		pageSize?: number;
+	};
+};
+
+type RuleCustomDataFilter<U> = {
+	[K in RuleCustomDataTypes]: U extends RuleCustomDataTypesMap[K] ? K : never;
+}[RuleCustomDataTypes];
+
+type RuleCustomDataEntryDefinition<T extends RuleCustomDataTypes = RuleCustomDataTypes> = {
+	type: T;
+	default: RuleCustomDataTypesMap[T] | (() => RuleCustomDataTypesMap[T]);
+	options?: T extends keyof RuleCustomDataTypesOptions ? RuleCustomDataTypesOptions[T] : undefined;
+	description: string;
+	Y?: number;
+};
+
+type RuleCustomDataEntryDefinitionStrict<ID extends keyof RuleCustomData, P extends keyof RuleCustomData[ID]> = RuleCustomDataEntryDefinition<RuleCustomDataFilter<RuleCustomData[ID][P]>>;
+
+interface RuleDisplayDefinition<ID extends BCX_Rule = BCX_Rule> {
+	name: string;
+	type: import("./modules/rules").RuleType;
+	shortDescription?: string;
+	longDescription: string;
+	keywords?: string[];
+	/** Texts to use for when rule is broken, set to empty string to disable */
+	triggerTexts?: {
+		/** When rule is broken */
+		infoBeep?: string;
+		/** When attempt to break rule is made; defaults to `infoBeep` */
+		attempt_infoBeep?: string;
+		/** When rule is broken */
+		log?: string;
+		/** When attempt to break rule is made */
+		attempt_log?: string;
+		/** When rule is broken; defaults to `log` */
+		announce?: string;
+		/** When attempt to break rule is made; defaults to `attempt_log` */
+		attempt_announce?: string;
+	};
+	defaultLimit: import("./constants").ConditionsLimit;
+	/** If rule can be enforced, defaults to `true` */
+	enforceable?: false;
+	/** If rule can be logged, defaults to `true` */
+	loggable?: false;
+	dataDefinition?: ID extends keyof RuleCustomData ? {
+		[P in keyof RuleCustomData[ID]]: RuleCustomDataEntryDefinitionStrict<ID, P>;
+	} : never;
+}
+
+interface RuleDefinition<ID extends BCX_Rule = BCX_Rule> extends RuleDisplayDefinition<ID> {
+	init?: (state: import("./modules/rules").RuleState<ID>) => void;
+	load?: (state: import("./modules/rules").RuleState<ID>) => void;
+	unload?: () => void;
+	stateChange?: (state: import("./modules/rules").RuleState<ID>, newState: boolean) => void;
+	tick?: (state: import("./modules/rules").RuleState<ID>) => boolean;
+	internalDataValidate?: ID extends keyof RuleInternalData ? (data: unknown) => boolean : never;
+	internalDataDefault?: ID extends keyof RuleInternalData ? () => RuleInternalData[ID] : never;
+}
+
+type BCX_Command =
+	| "eyes"
+	| "mouth"
+	| "arms"
+	| "legs"
+	| "allfours"
+	| "goandwait"
+	| "say"
+	| "forcesay"
+	| "typetask"
+	| "forcetypetask"
+	| "cell"
+	| "asylum"
+	| "keydeposit"
+	| "timeleft"
+	| "servedrinks"
+	| "orgasm"
+	| "emoticon"
+	;
+
+interface CommandDefinition<ID extends BCX_Command = BCX_Command> extends CommandDisplayDefinition {
+	init?: (state: import("./modules/commandsModule").CommandState<ID>) => void;
+	load?: (state: import("./modules/commandsModule").CommandState<ID>) => void;
+	unload?: () => void;
+	tick?: (state: import("./modules/commandsModule").CommandState<ID>) => boolean;
+	trigger: (
+		argv: string[],
+		sender: import("./characters").ChatroomCharacter,
+		respond: (msg: string) => void,
+		state: import("./modules/commandsModule").CommandState<ID>
+	) => boolean;
+	autoCompleter?: (
+		argv: string[],
+		sender: import("./characters").ChatroomCharacter
+	) => string[];
+}
+
+interface CommandDisplayDefinition {
+	name: string;
+	shortDescription?: string;
+	/**
+	 * Text shown in GUI when Player checks details of the command
+	 *
+	 * Following text replacements are made:
+	 * - `PLAYER_NAME` by name of viewed character
+	 * - `HELP_DESCRIPTION` by value of `helpDescription`
+	 */
+	longDescription: string;
+	helpDescription: string;
+	playerUsable?: boolean;
+	defaultLimit: import("./constants").ConditionsLimit;
+}
+
+interface RoomTemplate extends Omit<ServerChatRoomData, "Ban" | "MapData" | "Space" | "Character"> {
+	Locked?: never;
+	Private?: never;
+	Ban?: never;
+	MapData?: never;
+	Space?: never;
+	Character?: never;
+	AutoApply: true | undefined;
+}
+
+interface ModStorage {
+	version: string;
+	preset: import("./constants").Preset;
+	menuShouldDisplayTutorialHelp?: true;
+	chatShouldDisplayFirstTimeHelp?: true;
+	/** Toggle, if player chose to hide BCX icon in chatroom */
+	chatroomIconHidden?: true;
+	/** Toggle, if player chose to hide the supporter status */
+	supporterHidden?: true;
+	cheats: import("./constants").MiscCheat[];
+	disabledModules: import("./constants").ModuleCategory[];
+	permissions: PermissionsBundle;
+	owners: number[];
+	mistresses: number[];
+	log: import("./modules/log").LogEntry[];
+	logConfig: import("./modules/log").LogConfig;
+	typingIndicatorEnable: boolean;
+	typingIndicatorHideBC: boolean;
+	screenIndicatorEnable: boolean;
+	conditions: ConditionsStorage;
+	roomTemplates: (RoomTemplate | null)[];
+	roomSearchAutoFill: string;
+	relationships: import("./modules/relationships").RelationshipData[];
+	wardrobeDefaultExtended: boolean;
+	compatibilityCheckerWarningIgnore?: string;
+}
+
+interface ExtensionSettings {
+	BCX?: string | null;
+}

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -3,18 +3,6 @@ declare global {
   const NAME: string;
   const NICKNAME: string;
   const VERSION: string;
-  var ChatRoomCharacter: Array<any>;
-  var ChatRoomData: any;
-  var Commands: Array<any>;
-  var CurrentOnlinePlayers: number;
-  var CurrentScreen: any;
-  var data: {
-    Content: string;
-    Type: type;
-    Dictionary: {};
-    Target: number;
-    Sender: number;
-  };
 
   // unique to crabs
   interface Window {
@@ -22,134 +10,11 @@ declare global {
     sendWhisper: typeof WhisperPlus.sentWhisper;
     fakePlayerCommand: typeof Roster.fakePlayerCommand;
     crabsCloseItem: typeof Roster.close;
-    ChatRoomMessageWhisperPlus: typeof WhisperPlus.ChatRoomMessageWhisperPlusClick;
     crabsHelp: typeof HELP.showHelp;
-    CommandSet(payload: string): void;
   }
 
-  interface HTMLElement {
-    value: string;
-  }
-
-  interface Lovership {
-    Name: string;
-    MemberNumber?: number;
-    Stage?: 0 | 1 | 2;
-    Start?: number;
-  }
-
-  interface CharacterPoseMapping {
-    BodyLower?: string;
-    BodyFull?: string;
-    BodyAddon?: string;
-    [key: string]: any;
-  }
-
-  interface PlayerCharacter {
-    ID?: number;
-    Name: string;
-    MemberNumber?: number;
-    Type?: string;
-
-    AllowedInteractions: number;
-    LabelColor?: string;
-    LastChatRoom?: any;
-
-    Lover?: string;
-    Owner?: string;
-    Effect: string[];
-    Lovership: Lovership[];
-    Attribute: string[];
-    Appearance: any[];
-    Inventory: any[];
-    BlackList: Array<any>;
-    GhostList: Array<any>;
-    FriendList: Array<any>;
-    FriendNames: Map;
-    WhiteList: Array<any>;
-    BCT: any; // only for BCTweaks
-
-    PoseMapping: CharacterPoseMapping;
-    DrawPoseMapping: Record<string, any>;
-    ActivePoseMapping: Record<string, any>;
-    AllowedActivePoseMapping: Record<string, string[]>;
-
-    Stage: string;
-    CurrentDialog: string;
-
-    HasEffect(effect: string): boolean;
-    IsPlayer(): this is PlayerCharacter;
-    IsOwned(): boolean | string;
-    IsOwnedByCharacter(C: PlayerCharacter): boolean;
-    IsOwnedByPlayer(C: number): boolean;
-    IsLoverOfCharacter(C: PlayerCharacter): boolean;
-    GetLovership(MembersOnly?: boolean): Lovership[];
-    GetLoversNumbers(): Array<number>;
-    GetGenders(): string[];
-    GetPronouns(): string;
-    IsInFamilyOfMemberNumber(C: number): boolean;
-    OwnerNumber(): number;
-
-    ChatSettings: {
-      OOCAutoClose: boolean;
-    };
-
-    MapData: {
-      PrivateState: {
-        HasKeyBronze?: boolean;
-        HasKeySilver?: boolean;
-        HasKeyGold?: boolean;
-      };
-    };
-
-    // You can add the rest of the methods as needed
-  }
-
-  type QueueDataPayload = {
-    AllowedInteractions: typeof Player.AllowedInteractions;
-  };
-
-  declare const ServerAccountUpdate: {
-    QueueData(data: QueueDataPayload): void;
-  };
-
-  var Player: PlayerCharacter;
-
+  // XXX: this… doesn't exist, yet has a call?
   function addChatMessage(msg: string): void;
-  function CommandCombine(command: Array<any>);
-  function CharacterGetEffects(Player: PlayerCharacter): Array<string>;
-  function CharacterNickname(Player: PlayerCharacter): string;
-  function ChatRoomFocusCharacter(player: PlayerCharacter): void;
-  function ChatRoomGenerateChatRoomChatMessage(
-    type: string,
-    msg: string
-  ): {
-    Content: string;
-    Type: type;
-    Dictionary: {};
-    Target?: number;
-    Sender?: number;
-  };
-  function ChatRoomMessage(data: data): void;
-  function ChatRoomRegisterMessageHandler(message: {
-    Description: string;
-    Priority: number;
-    Callback: any;
-  }): any;
-  function ChatRoomSendLocal(Content: string, Timeout?: number): void;
-  function ChatRoomSendLocalChatRoomSendLocal(
-    Content: string,
-    Timeout?: number
-  ): void;
-  function ChatRoomStatusUpdate(payload: string): any;
-  function ChatRoomMapViewCharacterOnWhisperRange(
-    target: PlayerCharacter
-  ): boolean;
-  function ChatRoomMapViewIsActive(): boolean;
-  function ElementScrollToEnd(element: string): void;
-  function ServerSend(message: string, ...args: any): Promise;
-  function TextGet(text: string): void;
-  function TextGetInScope(path_to_csv: string, permission: string): void;
 }
 
 export {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,15 +88,6 @@ function argcheck(args: string): boolean {
   return true;
 }
 
-function commandRedirect(command: string, args: string): void {
-  for (const [_, COMMAND] of Commands.entries()) {
-    if (COMMAND.Tag === command) {
-      COMMAND.Action(args);
-      break;
-    }
-  }
-}
-
 // implements the whisper+ command
 CommandCombine([
   {
@@ -125,9 +116,7 @@ CommandCombine([
   {
     Tag: "crabs",
     Description: "Show the player count, helpful in maps.",
-    Action: (args: string) => {
-      commandRedirect("roster", args);
-    },
+    Reference: "roster",
   },
 ]);
 
@@ -167,9 +156,7 @@ CommandCombine([
   {
     Tag: "players",
     Description: "Deprecated: Show the player count, helpful in maps.",
-    Action: (args: string) => {
-      commandRedirect("roster", args);
-    },
+    Reference: "roster",
   },
 ]);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,6 @@ console.log(`CRABS v${VERSION} Loaded`); // do not remove
  * @returns void
  */
 function drawbanner() {
-  let output: string = "";
   // if the player left the room, bail!
   if (Player.LastChatRoom === null) {
     // Must return false, even if we are bailing out!
@@ -39,7 +38,7 @@ function drawbanner() {
 
   // configure extra roster input to the banner
   // TODO: make this optional in the future
-  let extradata = {
+  const extradata = {
     RosterCounters: ROSTER.buildroster("count", false),
   };
   BANNER.drawBanner(extradata);
@@ -52,7 +51,7 @@ function drawbanner() {
 ChatRoomRegisterMessageHandler({
   Description: "Send room stats on entry.",
   Priority: 0, // trigger immediately
-  Callback: (data: any) => {
+  Callback: (data) => {
     // check if we are a player and we entered a room
     if (
       data.Type === "Action" &&
@@ -194,19 +193,19 @@ CommandCombine([
       }
       for (let i = 0; i < splitArgs.length; i++) {
         if (splitArgs[i] == "bronze" || splitArgs[i] == "all") {
-          if (Player.MapData.PrivateState.HasKeyBronze) {
+          if (Player.MapData?.PrivateState.HasKeyBronze) {
             Player.MapData.PrivateState.HasKeyBronze = false;
             ChatRoomSendLocal(`Bronze key dropped.`);
           }
         }
         if (splitArgs[i] == "silver" || splitArgs[i] == "all") {
-          if (Player.MapData.PrivateState.HasKeySilver) {
+          if (Player.MapData?.PrivateState.HasKeySilver) {
             Player.MapData.PrivateState.HasKeySilver = false;
             ChatRoomSendLocal(`Silver key dropped.`);
           }
         }
         if (splitArgs[i] == "gold" || splitArgs[i] == "all") {
-          if (Player.MapData.PrivateState.HasKeyGold) {
+          if (Player.MapData?.PrivateState.HasKeyGold) {
             Player.MapData.PrivateState.HasKeyGold = false;
             ChatRoomSendLocal(`Gold key dropped.`);
           }

--- a/src/messages.d.ts
+++ b/src/messages.d.ts
@@ -1,0 +1,183 @@
+type BCX_beep_versionCheck = {
+	version: string;
+	devel: boolean;
+	GameVersion: string;
+	Source: string;
+	UA: string;
+};
+
+type BCX_beep_versionResponse = {
+	status: "unsupported" | "deprecated" | "newAvailable" | "current";
+	supporterStatus?: BCXSupporterType;
+	supporterSecret?: string;
+};
+
+type BCX_beeps = {
+	versionCheck: BCX_beep_versionCheck;
+	versionResponse: BCX_beep_versionResponse;
+	supporterCheck: {
+		memberNumber: number;
+		status: BCXSupporterType;
+		secret: string;
+	};
+	supporterCheckResult: {
+		memberNumber: number;
+		status: BCXSupporterType;
+	};
+	clearData: true;
+};
+
+type BCX_message_ChatRoomStatusEvent = {
+	Type: string;
+	Target: number | null;
+};
+
+/** BCX effects that should be visible to everyone in room */
+interface BCX_effects {
+	/** Any extra effects to be applied to character */
+	Effect: EffectName[];
+}
+
+type BCX_message_hello = {
+	version: string;
+	request: boolean;
+	effects?: Partial<BCX_effects>;
+	typingIndicatorEnable?: boolean;
+	screenIndicatorEnable?: boolean;
+	supporterStatus?: BCXSupporterType;
+	supporterSecret?: string;
+};
+
+type BCX_message_query = {
+	id: string;
+	query: keyof BCX_queries;
+	data?: any;
+};
+
+type BCX_message_queryAnswer = {
+	id: string;
+	ok: boolean;
+	data?: any;
+};
+
+type BCX_messages = {
+	ChatRoomStatusEvent: BCX_message_ChatRoomStatusEvent;
+	hello: BCX_message_hello;
+	goodbye: undefined;
+	query: BCX_message_query;
+	queryAnswer: BCX_message_queryAnswer;
+	somethingChanged: undefined;
+};
+
+type BCX_logAllowedActions = {
+	delete: boolean;
+	configure: boolean;
+	praise: boolean;
+	leaveMessage: boolean;
+};
+
+/**
+ * Queries BCX can send to other characters in the same room, or to oneself.
+ * Keys represent the name of the query, while values are `[question, answer]` pairs.
+ *
+ * `answer` cannot be `undefined`, as that is used to signal an error.
+ */
+type BCX_queries = {
+	disabledModules: [undefined, import("./constants").ModuleCategory[]];
+	commandHint: [string, [string, string][]];
+	permissions: [undefined, PermissionsBundle];
+	myAccessLevel: [undefined, import("./modules/authority").AccessLevel];
+	editPermission: [{
+		permission: BCX_Permissions;
+		edit: "self" | "min";
+		target: boolean | number;
+	}, boolean];
+	permissionAccess: [BCX_Permissions, boolean];
+	rolesData: [undefined, PermissionRoleBundle];
+	editRole: [
+		{
+			type: "owner" | "mistress";
+			action: "add" | "remove";
+			target: number;
+		},
+		boolean
+	];
+	logData: [undefined, import("./modules/log").LogEntry[]];
+	logDelete: [number | number[], boolean];
+	logConfigGet: [undefined, import("./modules/log").LogConfig];
+	logConfigEdit: [{
+		category: BCX_LogCategory;
+		target: import("./modules/log").LogAccessLevel;
+	}, boolean];
+	logClear: [undefined, boolean];
+	logPraise: [
+		{
+			message: string | null;
+			value: -1 | 0 | 1;
+		},
+		boolean
+	];
+	logGetAllowedActions: [undefined, BCX_logAllowedActions];
+	curseItem: [
+		{
+			Group: AssetGroupName;
+			curseProperties: boolean | null;
+		},
+		boolean
+	];
+	curseLift: [AssetGroupName, boolean];
+	curseLiftAll: [undefined, boolean];
+	curseBatch: [
+		{
+			mode: "items" | "clothes" | "body";
+			includingEmpty: boolean;
+		},
+		boolean
+	];
+	conditionsGet: [ConditionsCategories, ConditionsCategoryPublicData<ConditionsCategories>];
+	conditionSetLimit: [{
+		category: ConditionsCategories;
+		condition: ConditionsCategoryKeys[ConditionsCategories];
+		limit: import("./constants").ConditionsLimit;
+	}, boolean];
+	conditionUpdate: [{
+		category: ConditionsCategories;
+		condition: ConditionsCategoryKeys[ConditionsCategories];
+		data: ConditionsConditionPublicData;
+	}, boolean];
+	conditionUpdateMultiple: [{
+		category: ConditionsCategories;
+		conditions: (ConditionsCategoryKeys[ConditionsCategories])[];
+		data: Partial<ConditionsConditionPublicDataBase>;
+	}, boolean];
+	conditionCategoryUpdate: [{
+		category: ConditionsCategories;
+		data: ConditionsCategoryConfigurableData;
+	}, boolean];
+	ruleCreate: [BCX_Rule, boolean];
+	ruleDelete: [BCX_Rule, boolean];
+	rule_alt_allow_changing_appearance: [undefined, boolean];
+	commandTrigger: [[BCX_Command, ...string[]], boolean];
+	export_import_do_export: [{
+		category: string;
+		compress: boolean;
+	}, string];
+	export_import_do_import: [{
+		category: string;
+		data: string;
+	}, string];
+	relatonshipsGet: [undefined, {
+		relationships: import("./modules/relationships").RelationshipData[];
+		access_view_all: boolean;
+		access_modify_self: boolean;
+		access_modify_others: boolean;
+	}];
+	relationshipsRemove: [number, boolean];
+	relationshipsSet: [import("./modules/relationships").RelationshipData, boolean];
+};
+
+type __BCX_queries_satisfies = Satisfies<BCX_queries, Record<string, [any, any]>>;
+type __BCX_queires_no_undefined_result = {
+	[key in keyof BCX_queries]: undefined extends BCX_queries[key][1] ? false : true;
+};
+type __BCX_queries_no_undefined_result_satisfies = Satisfies<__BCX_queires_no_undefined_result, Record<string, true>>;

--- a/src/modules/banner.ts
+++ b/src/modules/banner.ts
@@ -21,10 +21,10 @@ export class Banner extends CRABS {
     if (select) {
       select.addEventListener("change", (event: Event) => {
         const TARGET = event.target as HTMLSelectElement;
-        const NEW_PERM_LEVEL = parseInt(TARGET.value, 10);
+        const NEW_PERM_LEVEL = CommonParseInt(TARGET.value, 10) ?? 0;
 
         // Update player permissions based on selection
-        Player.AllowedInteractions = NEW_PERM_LEVEL;
+        Player.AllowedInteractions = CommonClamp(NEW_PERM_LEVEL, 0, 5) as AllowedInteractions;
         ServerAccountUpdate.QueueData({ AllowedInteractions: Player.AllowedInteractions });
       });
     } else {

--- a/src/modules/banner.ts
+++ b/src/modules/banner.ts
@@ -39,7 +39,7 @@ export class Banner extends CRABS {
    */
   private drawPermission(): string {
     let output: string = "";
-    let SELECTED: number = Player.AllowedInteractions;
+    const SELECTED: number = Player.AllowedInteractions;
 
     // TODO: update this to support an arbitrary number of permission levels.
     for (const NUMBER of [0, 1, 2, 3, 4, 5]) {
@@ -70,14 +70,14 @@ export class Banner extends CRABS {
     }
 
     // set up the template and populate the fields.
-    let templatevars = {
+    const templatevars = {
       Logo: this.printimage("logo", undefined, "CRABS_logo"),
       LabelColor: `${Player.LabelColor}`,
       PermissionOptions: this.drawPermission(),
       RoomName: ChatRoomData.Name,
     };
 
-    let wrappervars = {
+    const wrappervars = {
       TitleBar: `${NAME}:  ${VERSION}`,
       Close: this.printimage("close", undefined, "CRABS_close", undefined, [
         "elementid",

--- a/src/modules/roster.ts
+++ b/src/modules/roster.ts
@@ -57,10 +57,10 @@ export class Roster extends CRABS {
   /** 
    * Determines if a player is Deaf, Blind, or Gagged and sets icons accordingly.
    * 
-   * @param {PlayerCharacter} player - Player Charater, the player object.
-   * @returns {string} List of icons.
+   * @param player - Player Charater, the player object.
+   * @returns List of icons.
    */
-  private setStatusIcons(player: PlayerCharacter): string {
+  private setStatusIcons(player: Character): string {
     const PREFIXES = ["Blind", "Gag", "Deaf"];
     const EFFECTS = CharacterGetEffects(player);
 
@@ -94,7 +94,7 @@ export class Roster extends CRABS {
     };
 
     // Initialize icons as empty strings
-    let icons: { [key: string]: string } = {
+    const icons: { [key: string]: string } = {
       Blind: "",
       Gag: "",
       Deaf: "",
@@ -124,8 +124,8 @@ export class Roster extends CRABS {
     };
 
     // Process effects
-    for (let effect of EFFECTS) {
-      for (let prefix of PREFIXES) {
+    for (const effect of EFFECTS) {
+      for (const prefix of PREFIXES) {
         if (effect.startsWith(prefix)) {
           updateIcon(prefix, effect);
         }
@@ -148,17 +148,17 @@ export class Roster extends CRABS {
   /** 
    * Builds the cards that get injected into the roster.
    * 
-   * @param {PlayerCharacter} player - Player character that we are working with.
-   * @param {string} badge - String for the badge showing if the player is admin.
-   * @param {string} player_icons - String for the different icons relevant to the player.
-   * @returns {string} The output html from the template.
+   * @param player - Player character that we are working with.
+   * @param badge - String for the badge showing if the player is admin.
+   * @param player_icons - String for the different icons relevant to the player.
+   * @returns The output html from the template.
    */
   private buildCard(
-    player: PlayerCharacter,
+    player: Character,
     badge: string,
     player_icons: string
   ): string {
-    let templatevars: Record<string, string> = {
+    const templatevars: Record<string, string> = {
       PlayerNumber: `${player.MemberNumber}`,
       Badge: badge,
       LabelColorBorder: `${this.convertColor(
@@ -181,7 +181,7 @@ export class Roster extends CRABS {
    */
   private loadFriendList(): void {
     this.crabs.hookFunction("FriendListLoadFriendList", 0, (args, next) => {
-      const [DATA]: Array<Record<string, any>> = args;
+      const [DATA] = args;
       this.onlineFriends = DATA.length;
       this.lastSentTime = Date.now();
       return next(args);
@@ -231,15 +231,13 @@ export class Roster extends CRABS {
 
   /** 
    * Determine if player is admin or whitelisted in the room and set their badge icon.
-   * 
-   * @returns void
    */
-  private setbadge(player: PlayerCharacter): string {
+  private setbadge(player: Character): string {
     let badge = this.printimage("player", "Guest", "CRABS_badge");
-    badge = ChatRoomData.Whitelist.includes(player.MemberNumber)
+    badge = ChatRoomData?.Whitelist.includes(player.MemberNumber ?? -1)
       ? this.printimage("vip", "VIP", "CRABS_badge")
       : badge;
-    badge = ChatRoomData.Admin.includes(player.MemberNumber)
+    badge = ChatRoomData?.Admin.includes(player.MemberNumber ?? -1)
       ? this.printimage("admin", "Admin", "CRABS_badge")
       : badge;
     return badge;
@@ -248,17 +246,17 @@ export class Roster extends CRABS {
   /**
    * Sets the icons relevant to the player
    * 
-   * @param {PlayerCharacter} player - Player character object.
-   * @return {string} HTML string containing the icons.
+   * @param player - Player character object.
+   * @return HTML string containing the icons.
    */
-  private setIcons(player: PlayerCharacter): string {
+  private setIcons(player: Character): string {
     let player_icons = "";
     if (Player.OwnerNumber() == player.MemberNumber) {
       // person owns you
       player_icons += this.printimage("owner", "Your Owner") + " ";
     } else if (Player.IsInFamilyOfMemberNumber(player.MemberNumber ?? -1)) {
       // if they don't own you but you are in their family, we assume you own them
-      if (Player.IsOwnedByPlayer(player.MemberNumber ?? -1)) {
+      if (player.IsOwned()) {
         // The person is fully owned if this is true
         player_icons += this.printimage("sub", "Submissive") + " ";
       } else {
@@ -273,27 +271,28 @@ export class Roster extends CRABS {
       if (this.detectMod("BCTweaks")) {
         // BCTweaks mod is found
         if (
+          // @ts-expect-error no typings for that
           Player.BCT.bctSettings.bestFriendsList.includes(player.MemberNumber)
         ) {
           //Player is a best friend, skip checking if they are a friend.
           player_icons += this.printimage("bestfriend", "Best Friend") + " ";
-        } else if (Player.FriendList.includes(player.MemberNumber)) {
+        } else if (Player.FriendList.includes(player.MemberNumber ?? -1)) {
           // Player is not a best friend, but they are a friend
           player_icons += this.printimage("friend", "Friend") + " ";
         }
-      } else if (Player.FriendList.includes(player.MemberNumber)) {
+      } else if (Player.FriendList.includes(player.MemberNumber ?? -1)) {
         // person is a friend, and the BCTweaks mod is not found
         player_icons += this.printimage("friend", "Friend") + " ";
       }
     }
-    if (Player.WhiteList.includes(player.MemberNumber)) {
+    if (Player.WhiteList.includes(player.MemberNumber ?? -1)) {
       // Player is whitelisted
       player_icons += this.printimage("whitelist", "Whitelist") + " ";
-    } else if (Player.BlackList.includes(player.MemberNumber)) {
+    } else if (Player.BlackList.includes(player.MemberNumber ?? -1)) {
       // Player is blacklisted
       player_icons += this.printimage("blacklist", "Blacklist") + " ";
     }
-    if (Player.GhostList.includes(player.MemberNumber)) {
+    if (Player.GhostList.includes(player.MemberNumber ?? -1)) {
       // Player is ghosted
       player_icons += this.printimage("ghost", "Ghosted") + " ";
     }
@@ -328,7 +327,6 @@ export class Roster extends CRABS {
     let showadmins = true; // room admins
     let showvip = true; // room whitelists
     let showplayers = true; // normal players
-    let templatevars: Record<string, string>;
     let output_html: string = ""
 
     //get a list of players
@@ -383,7 +381,7 @@ export class Roster extends CRABS {
     }
 
     // if argument is "count", set filter vars and skip loop
-    if (SPLITARGS.some((item: any) => item.toLowerCase() === "count")) {
+    if (SPLITARGS.some((item) => item.toLowerCase() === "count")) {
       showme = false;
       showadmins = false;
       showvip = false;
@@ -391,27 +389,27 @@ export class Roster extends CRABS {
     }
 
     // if argument is admins, set filter vars to only show admins and continue
-    if (SPLITARGS.some((item: any) => item.toLowerCase() === "admins")) {
+    if (SPLITARGS.some((item) => item.toLowerCase() === "admins")) {
       showme = false;
       showvip = false;
       showplayers = false;
     }
 
     // if argument is vips, set filter vars to only show vips (white listed) and continue
-    if (SPLITARGS.some((item: any) => item.toLowerCase() === "vips")) {
+    if (SPLITARGS.some((item) => item.toLowerCase() === "vips")) {
       showme = false;
       showadmins = false;
       showplayers = false;
     }
 
     // build table header
-    templatevars = {
+    const templatevars: Record<string, string> = {
       adminIcon: `${this.printimage("admin", "Admins", "CRABS_header_icons")}`,
       adminsInRoom: `${admin_count}`,
-      totalAdmins: `${ChatRoomData.Admin.length}`,
+      totalAdmins: `${ChatRoomData?.Admin.length ?? 0}`,
       playerIcon: `${this.printimage("player", "Players", "CRABS_header_icons")}`,
       playersInRoom: `${ChatRoomCharacter.length}`,
-      totalPlayers: `${ChatRoomData.Limit}`,
+      totalPlayers: `${ChatRoomData?.Limit ?? `<unknown>`}`,
       friendIcon: `${this.printimage("friend", "Friends", "CRABS_header_icons")}`,
       friendsOnline: this.onlineFriends?.toString() ?? "...",
       totalFriends: `${Player.FriendNames.size}`,
@@ -425,9 +423,9 @@ export class Roster extends CRABS {
 
       // build a dictionary of the keys
       const KEYS = {
-        keyBronze: Player.MapData.PrivateState.HasKeyBronze,
-        keySilver: Player.MapData.PrivateState.HasKeySilver,
-        keyGold: Player.MapData.PrivateState.HasKeyGold,
+        keyBronze: Player.MapData?.PrivateState.HasKeyBronze,
+        keySilver: Player.MapData?.PrivateState.HasKeySilver,
+        keyGold: Player.MapData?.PrivateState.HasKeyGold,
       };
 
       // loop the dictionary and extract the key and name
@@ -456,7 +454,7 @@ export class Roster extends CRABS {
     output_rows = showplayers ? output_rows + player_output_html : output_rows;
     templatevars["playerRows"] = output_rows;
 
-    let wrappervars = {
+    const wrappervars: Record<string, string> = {
         TitleBar: `CRABS: Roster`,
         Close: this.printimage("close", undefined, "CRABS_close", undefined, ["elementid", "CRABS_Roster"])
     }

--- a/src/modules/roster.ts
+++ b/src/modules/roster.ts
@@ -316,11 +316,9 @@ export class Roster extends CRABS {
     let admin_output_html: string = "" // holds admins
     let vip_output_html: string = "" // holds whitelisted users
     let player_output_html : string = "" // holds normal players
-    let player: PlayerCharacter; // the person we found in the room
     let admin_count = 0; // number of admins in the room
     let badge = ""; // holds the admin icon if the player is an admin
     let player_icons = ""; // holds the list of player/status icons (string)
-    let MemberNumber: number;
 
     // filter variables, show or not show certain output
     let showme = true; // person who ran the script (you)
@@ -330,53 +328,47 @@ export class Roster extends CRABS {
     let output_html: string = ""
 
     //get a list of players
-    for (let person in ChatRoomData.Character) {
-      // find member number for current player in list
-      MemberNumber = ChatRoomData.Character[person].MemberNumber;
-
-      // Find player
-      player = ChatRoomCharacter.find(
-        (C: any) => C.MemberNumber == MemberNumber
-      );
+    for (const char of ChatRoomCharacter) {
+      const charNumber = char.MemberNumber ?? -1;
 
       //bail out and return placeholder if player is not available.
-      if (!player) {
+      if (!char) {
         player_output_html +=
             "❓ <span style='color:#FF0000'>[Unknown Person]</span>\n";
         continue;
       }
 
       // check if the player is also an admin or vip and add icon with admin given priority
-      badge = this.setbadge(player);
-      player_icons = this.setIcons(player);
+      badge = this.setbadge(char);
+      player_icons = this.setIcons(char);
 
       // if the player is me (person who ran the script)
-      if (player.IsPlayer()) {
+      if (char.IsPlayer()) {
         // mark me with a star icon
         player_icons = this.printimage("you", "You") + " " + player_icons;
 
         // format my output and store
-        me_output_html = this.buildCard(player, badge, player_icons);
+        me_output_html = this.buildCard(char, badge, player_icons);
       }
 
       // check if the player is an admin and update the count, also flag the player as admin in the output list.
-      if (ChatRoomData.Admin.includes(player.MemberNumber)) {
+      if (ChatRoomData?.Admin.includes(charNumber)) {
         admin_count++;
-        if (!player.IsPlayer()) {
+        if (!char.IsPlayer()) {
           // if the player is not me, output admin and skip rest of loop
-          admin_output_html += this.buildCard(player, badge, player_icons);
+          admin_output_html += this.buildCard(char, badge, player_icons);
           continue;
         }
       } else if (
-        ChatRoomData.Whitelist.includes(player.MemberNumber) &&
-        !player.IsPlayer()
+        ChatRoomData?.Whitelist.includes(charNumber) &&
+        !char.IsPlayer()
       ) {
         // if the player isn't an admin, is the player is white listed?
-        vip_output_html += this.buildCard(player, badge, player_icons);
+        vip_output_html += this.buildCard(char, badge, player_icons);
         continue;
-      } else if (!player.IsPlayer()) {
+      } else if (!char.IsPlayer()) {
         // player is normal, nonadmin, not whitelist, and not me.
-        player_output_html += this.buildCard(player, badge, player_icons);
+        player_output_html += this.buildCard(char, badge, player_icons);
       }
     }
 

--- a/src/modules/whisperplus.ts
+++ b/src/modules/whisperplus.ts
@@ -1,5 +1,6 @@
 import {ModSDKModAPI} from "bondage-club-mod-sdk";
 import CRABS from "../base"
+import { isBCXRuleEnforced } from "../bcx";
 export class WhisperPlus extends CRABS {
 
     constructor(CRABS: ModSDKModAPI) {
@@ -15,6 +16,11 @@ export class WhisperPlus extends CRABS {
      */
     private ChatRoomSendWhisperRanged(targetArg: Character | number, msg: string): boolean {
         if (msg == "") {
+            return false;
+        }
+
+        if (isBCXRuleEnforced("speech_restrict_whisper_send")) {
+            ChatRoomSendLocal(`Sending whispers is blocked by BCX.`, 30_000);
             return false;
         }
 

--- a/src/modules/whisperplus.ts
+++ b/src/modules/whisperplus.ts
@@ -9,24 +9,24 @@ export class WhisperPlus extends CRABS {
     /** 
      * Send chat message at range.
      * 
-     * @param {any} target - whisper target.
+     * @param {Character} target - whisper target.
      * @param {string} string - message to send.
      * @returns {boolean} Was the message sent?
      */
-    private ChatRoomSendWhisperRanged(target: any, msg: string): boolean {
+    private ChatRoomSendWhisperRanged(targetArg: Character | number, msg: string): boolean {
         if (msg == "") {
             return false;
         }
 
         // First ensure we have a valid target object
-        const TARGETMEMEBER = typeof target === 'object' ? target : ChatRoomCharacter.find(C => C.MemberNumber === parseInt(target));
-        if (!TARGETMEMEBER) {
-            ChatRoomSendLocalChatRoomSendLocal(`${TextGet("CommandNoWhisperTarget")} ${target}.`, 30_000);
+        const target = typeof targetArg === 'object' ? targetArg : ChatRoomCharacter.find(C => C.MemberNumber === parseInt(targetArg, 10));
+        if (!target) {
+            ChatRoomSendLocal(`${TextGet("CommandNoWhisperTarget")} ${targetArg}.`, 30_000);
             return false;
         }
 
         // Handle self whispers with gray text and memo emoji
-        if (TARGETMEMEBER.MemberNumber === Player.MemberNumber) {
+        if (target.MemberNumber === Player.MemberNumber) {
             const SELFMESSAGE = `<span style="color:#989898">${this.printimage("thought")} Note to </span><span style="color:${Player.LabelColor}">self</span><span style="color:#989898">: ${msg}</span>`;
             ChatRoomSendLocal(SELFMESSAGE);
             return false;
@@ -38,7 +38,7 @@ export class WhisperPlus extends CRABS {
 
 
         // check if target and player are the same
-        if (target.MemberNumber == Player.MemberNumber) {
+        if (target.IsPlayer()) {
             addChatMessage(msg);
         } else {
             if (ChatRoomMapViewIsActive() && !ChatRoomMapViewCharacterOnWhisperRange(target) && msg[0] != "(") {
@@ -46,13 +46,13 @@ export class WhisperPlus extends CRABS {
             }
 
             // Prepare the message - now with ⤵ instead of :
-            let formattedMsg = `+: ${msg}`;
+            const formattedMsg = `+: ${msg}`;
             //if (Player.ChatSettings.OOCAutoClose && !msg.endsWith('）')) {
             //    formattedMsg += '）';
             //}
 
             // build data payload
-            let data = ChatRoomGenerateChatRoomChatMessage("Whisper", formattedMsg);
+            const data = ChatRoomGenerateChatRoomChatMessage("Whisper", formattedMsg);
             /*if (!data) {
                 data = ChatRoomGenerateChatRoomChatMessage("Whisper", formattedMsg);
             }*/
@@ -61,7 +61,7 @@ export class WhisperPlus extends CRABS {
             data.Target = target.MemberNumber;
 
             //send the whisper
-            const serverData = { ...data, Type: "Whisper" }
+            const serverData: ServerChatRoomMessage = { ...data, Type: "Whisper" }
             ServerSend("ChatRoomChat", serverData);
 
             // tell it who we are
@@ -116,7 +116,7 @@ export class WhisperPlus extends CRABS {
 
         // find player based no membernumber
         const TARGET = ChatRoomCharacter.find(
-            (C: any) => C.MemberNumber == MEMBERNUMBER
+            (C) => C.MemberNumber == MEMBERNUMBER
         );
         this.ChatRoomSendWhisperRanged(TARGET || MEMBERNUMBER, MESSAGE);
         return 0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,8 @@
     "skipLibCheck": true,    // Skip type checking of declaration files
     "strict": true           // Enables strict mode (good practice)
   },
-  "include": ["src/**/*.ts"] // Include your source TypeScript files
+  "include": [
+    "node_modules/bc-stubs/bc/**/*.d.ts",
+    "src/**/*.ts",
+  ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
-    "target": "ES6",         // Target ECMAScript version (you can change it based on your needs)
-    "module": "ESNext",      // Rollup works best with ES Modules
+    "target": "ES6",
+    "module": "ESNext",
     "moduleResolution": "node",
-    "outDir": "../Live/CRABS/Alpha",      // Output directory
-    "esModuleInterop": true, // Allows importing non-ES6 modules (like CommonJS)
-    "skipLibCheck": true,    // Skip type checking of declaration files
-    "strict": true           // Enables strict mode (good practice)
+    "outDir": "../Live/CRABS/Alpha",
+    "esModuleInterop": true, 
+    "skipLibCheck": true, 
+    "strict": true  
   },
   "include": [
     "node_modules/bc-stubs/bc/**/*.d.ts",
-    "src/**/*.ts",
-  ],
+    "src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
This is based on the Alpha branch. If that's not the proper "mainline" branch do tell and I'll move stuff around.

This fixes some of the problems I could spot:
- `bc-stubs` was there but not actually used, so that's been cleaned up.
- Some things you know when you know BC, like making command aliases (though you'd have to check what `/help` looks like).
- a bit of cleanup of some names, because having a character variable named `player` made me do a spit-take when I encountered… `Player.IsOwnedByPlayer(player.MemberNumber ?? -1)` (in the "submissive" icon check, I think?) which makes no sense; that function doesn't take an argument, it's there to check *someone else* against Player.

Then finally the part I was after; making `/whisper+` respect the BCX whisper rule.

Warning: this is full yolo mode and untested, so handle with care. It *should* work, byt YMMV.